### PR TITLE
Relax puma gem constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: false
 cache:
   - bundler
 rvm:
-- 2.3.1
+- 2.6
 script: bundle exec rspec

--- a/lib/zooniverse_social/version.rb
+++ b/lib/zooniverse_social/version.rb
@@ -1,3 +1,3 @@
 module ZooniverseSocial
-  VERSION = '1.0.6'
+  VERSION = '1.1.0'
 end

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'puma', '~> 3.2'
+  spec.add_runtime_dependency 'puma'
   spec.add_runtime_dependency 'sinatra', '~> 1.4'
   spec.add_runtime_dependency 'twitter', '~> 5.16'
   spec.add_runtime_dependency 'faraday', '~> 0.9'


### PR DESCRIPTION
Enusre we have puma but don't restrict it being upgraded, allow the app including to specify the puma version constraint
bump the version for release