### PR TITLE
Relax sinatra constraint

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -1,0 +1,25 @@
+name: Zooni CI
+on:
+  pull_request:
+  push: { branches: master }
+jobs:
+env:
+  DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/${{ inputs.db_name }}
+  RAILS_ENV: test
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.1.0
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -2,13 +2,10 @@ name: Zooni CI
 on:
   pull_request:
   push: { branches: master }
-jobs:
 env:
-  DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/${{ inputs.db_name }}
   RAILS_ENV: test
-
 jobs:
-  tests:
+  test:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-sudo: false
-cache:
-  - bundler
-rvm:
-- 2.6
-script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Or install it yourself as:
 
 ## Usage
 
+### Boot the application
+Run the app via the rackup cmd, <https://github.com/sinatra/sinatra#serving-a-modular-application>
+
+`bundle exec rackup -p 4567`
+
 ### Install dependencies
 `bundle install`
 
@@ -29,11 +34,11 @@ Or install it yourself as:
 `bundle exec rspec`
 
 ### Publishing to [RubyGems](https://rubygems.org/)
-`rake build` - to create the new gem version locally  
+`rake build` - to create the new gem version locally
 `rake release` - to tag the gem and release it to RubyGems
 
 ## License
 
-Copyright 2016 by the Zooniverse
+Copyright 2022 by the Zooniverse
 
 The gem is available as open source under the terms of the [Apache License v2](https://opensource.org/licenses/Apache-2.0).

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -26,11 +26,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'concurrent-ruby-ext', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rack-test', '~> 0.6'
-  spec.add_development_dependency 'webmock', '~> 2.1'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'pry'
 end

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'puma'
-  spec.add_runtime_dependency 'sinatra', '~> 1.4'
+  spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'twitter', '~> 5.16'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'puma'
-  spec.add_runtime_dependency 'sinatra'
+  spec.add_runtime_dependency 'sinatra', '>= 2.2'
   spec.add_runtime_dependency 'twitter', '~> 5.16'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'puma'
-  spec.add_runtime_dependency 'sinatra', '>= 3'
+  spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'twitter', '~> 5.16'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'

--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'puma'
-  spec.add_runtime_dependency 'sinatra'
+  spec.add_runtime_dependency 'sinatra', '>= 3'
   spec.add_runtime_dependency 'twitter', '~> 5.16'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'


### PR DESCRIPTION
Relax the sinatra constraint to allow up to date installs but also allow the mounting app to specify the version constraint for greater flexibility.

Also this PR updates the CI sytem to GH actions from travis