### PR TITLE
Leave Faraday alone

### DIFF
--- a/zooniverse_social.gemspec
+++ b/zooniverse_social.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'concurrent-ruby-ext', '~> 1.0'
-  spec.add_runtime_dependency 'faraday', '~> 2.7'
+  spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'puma'
   spec.add_runtime_dependency 'sinatra', '>= 2.2'
 


### PR DESCRIPTION
Turns out Talk has a `~> 0.9` lock on Faraday in its own Gemfile, which contradicts this and updating it over there causes more issues than it solves. 1.3.0 was yanked from rubygems and will be reuploaded after this (proactive, unnecessary) dependency update is walked back. As gems are updated over there, I'll have to remember to update this, too.