### PR TITLE
Update gem to v1.3.1

### DIFF
--- a/lib/zooniverse_social/version.rb
+++ b/lib/zooniverse_social/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZooniverseSocial
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Update gem to v1.3.1. Version 1.3.0 was yanked due to an updated dependency that clashed with Talk's gemfile restrictions.